### PR TITLE
Fix retained probabilities

### DIFF
--- a/datasets/domainnet/generate_dataset.py
+++ b/datasets/domainnet/generate_dataset.py
@@ -214,10 +214,10 @@ def apply(model, dataset, model_classes, device, batch_size=512):
         inputs = x.to(device)
         proba = torch.softmax(model(inputs), 1)
 
-        _, preds = torch.max(proba, 1)
+        probs, preds = torch.max(proba, 1)
 
         predictions.extend(preds.tolist())
-        probas.extend(proba.tolist())
+        probas.extend(probs.tolist())
 
     model.train()
     target_class = target_dataset.classes


### PR DESCRIPTION
This pull request removes a bug which lead to the wrong probabilities being stored along with the predictions of each labeling function. 

Previously, all probabilities (2d tensor of size batch by classes) were saved alongside the class predictions. However, what was supposed to be saved is the probability associated with each prediction of the model. 